### PR TITLE
Use 4.3.x until 4.4.8 is merged.

### DIFF
--- a/nd-conda.sh
+++ b/nd-conda.sh
@@ -17,10 +17,11 @@ if [[ ! -f $CONDA_ROOT/installed ]]; then
         [[ -z $USER ]] && USER=root
         sudo chown $USER $CONDA_ROOT
     fi
+    # TODO(justyn): Flip back to using latest once 4.4.8 is released (contains a critical bug fix).
     if [[ "$(uname)" == "Darwin" ]]; then
-        URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
+        URL="https://repo.continuum.io/miniconda/Miniconda3-4.3.31-MacOSX-x86_64.sh"
     else
-        URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
+        URL="https://repo.continuum.io/miniconda/Miniconda3-4.3.31-Linux-x86_64.sh"
     fi
     curl "$URL" > miniconda.sh
     bash miniconda.sh -b -f -p $CONDA_ROOT


### PR DESCRIPTION
Use Conda version 4.3.31 in order to support private repositories until 4.4.8 is merged (code is into the 4.4.x branch in Conda but hasn't been released yet. https://github.com/conda/conda/issues/6745)