### PR TITLE
Upgrade conda

### DIFF
--- a/nd-conda.sh
+++ b/nd-conda.sh
@@ -7,6 +7,10 @@ else
     exit 1
 fi
 
+VERSION="4.5.4"
+LINUX_MD5="a946ea1d0c4a642ddf0c3a26a18bb16d"
+MAC_MD5="164ec263c4070db642ce31bb45d68813"
+
 # Get miniconda if it doesn't exist.
 if [[ ! -f $CONDA_ROOT/installed ]]; then
     echo "Installing Conda to $CONDA_ROOT."
@@ -17,13 +21,21 @@ if [[ ! -f $CONDA_ROOT/installed ]]; then
         [[ -z $USER ]] && USER=root
         sudo chown $USER $CONDA_ROOT
     fi
-    # TODO(justyn): Flip back to using latest once 4.4.8 is released (contains a critical bug fix).
     if [[ "$(uname)" == "Darwin" ]]; then
-        URL="https://repo.continuum.io/miniconda/Miniconda3-4.3.31-MacOSX-x86_64.sh"
+        URL="https://repo.continuum.io/miniconda/Miniconda3-$VERSION-MacOSX-x86_64.sh"
+        curl "$URL" > miniconda.sh
+        HASH=$(md5 -r miniconda.sh | cut -d" "  -f1)
+        if [ "$HASH" != "$MAC_MD5" ]; then
+            exit 1
+        fi
     else
-        URL="https://repo.continuum.io/miniconda/Miniconda3-4.3.31-Linux-x86_64.sh"
+        URL="https://repo.continuum.io/miniconda/Miniconda3-$VERSION-Linux-x86_64.sh"
+        curl "$URL" > miniconda.sh
+        HASH=$(md5sum miniconda.sh | cut -d" "  -f1)
+        if [ "$HASH" != "$MAC_MD5" ]; then
+            exit 1
+        fi
     fi
-    curl "$URL" > miniconda.sh
     bash miniconda.sh -b -f -p $CONDA_ROOT
     rm -f miniconda.sh
     touch $CONDA_ROOT/installed


### PR DESCRIPTION
This upgrades us to the latest conda.  This should be transparent to devs, but will make it possible to put `conda` the dev environment path without masking the default system python