### PR TITLE
Allow conda version to be overridden with a CONDA_VERSION env variable

### DIFF
--- a/nd-conda.sh
+++ b/nd-conda.sh
@@ -1,5 +1,13 @@
 #!/bin/bash -e
 
+
+VERSION="4.3.11"
+
+# Allow CONDA_VERSION env variable to override the default
+if [[ $CONDA_VERSION ]]; then
+    VERSION=$CONDA_VERSION
+fi
+
 if [[ $# == 1 ]]; then
     CONDA_ROOT=$1
 else
@@ -9,7 +17,7 @@ fi
 
 # Get miniconda if it doesn't exist.
 if [[ ! -f $CONDA_ROOT/installed ]]; then
-    echo "Installing Conda to $CONDA_ROOT."
+    echo "Installing Conda version $CONDA_VERSION to $CONDA_ROOT."
     if ! which sudo > /dev/null; then
         [[ ! -d $CONDA_ROOT ]] && mkdir $CONDA_ROOT
     else
@@ -17,11 +25,10 @@ if [[ ! -f $CONDA_ROOT/installed ]]; then
         [[ -z $USER ]] && USER=root
         sudo chown $USER $CONDA_ROOT
     fi
-    # TODO(justyn): Flip back to using latest once 4.4.8 is released (contains a critical bug fix).
     if [[ "$(uname)" == "Darwin" ]]; then
-        URL="https://repo.continuum.io/miniconda/Miniconda3-4.3.31-MacOSX-x86_64.sh"
+        URL="https://repo.continuum.io/miniconda/Miniconda3-$CONDA_VERSION-MacOSX-x86_64.sh"
     else
-        URL="https://repo.continuum.io/miniconda/Miniconda3-4.3.31-Linux-x86_64.sh"
+        URL="https://repo.continuum.io/miniconda/Miniconda3-$CONDA_VERSION-Linux-x86_64.sh"
     fi
     curl "$URL" > miniconda.sh
     bash miniconda.sh -b -f -p $CONDA_ROOT

--- a/nd-conda.sh
+++ b/nd-conda.sh
@@ -17,7 +17,7 @@ fi
 
 # Get miniconda if it doesn't exist.
 if [[ ! -f $CONDA_ROOT/installed ]]; then
-    echo "Installing Conda version $CONDA_VERSION to $CONDA_ROOT."
+    echo "Installing Conda version $VERSION to $CONDA_ROOT."
     if ! which sudo > /dev/null; then
         [[ ! -d $CONDA_ROOT ]] && mkdir $CONDA_ROOT
     else
@@ -26,9 +26,9 @@ if [[ ! -f $CONDA_ROOT/installed ]]; then
         sudo chown $USER $CONDA_ROOT
     fi
     if [[ "$(uname)" == "Darwin" ]]; then
-        URL="https://repo.continuum.io/miniconda/Miniconda3-$CONDA_VERSION-MacOSX-x86_64.sh"
+        URL="https://repo.continuum.io/miniconda/Miniconda3-$VERSION-MacOSX-x86_64.sh"
     else
-        URL="https://repo.continuum.io/miniconda/Miniconda3-$CONDA_VERSION-Linux-x86_64.sh"
+        URL="https://repo.continuum.io/miniconda/Miniconda3-$VERSION-Linux-x86_64.sh"
     fi
     curl "$URL" > miniconda.sh
     bash miniconda.sh -b -f -p $CONDA_ROOT


### PR DESCRIPTION
Provides a means to selectively rollout a conda upgrade to 4.5.11.